### PR TITLE
Fix/fullname override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_Store
+
+# Jetbrains IDEs
+.idea
+*.iml

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -43,6 +43,12 @@ Compile all warnings into a single message.
 {{- end -}}
 
 
+{{/*
+Return Novu API deployment full name
+*/}}
+{{- define "novu-api.fullname" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) "api" -}}
+{{- end -}}
 
 {{/*
 Return the proper api image name
@@ -58,7 +64,12 @@ Return the proper image name (for the init container volume-permissions image)
 {{- include "common.images.image" ( dict "imageRoot" "global" .Values.global ) -}}
 {{- end -}}
 
-
+{{/*
+Return Novu Worker deployment full name
+*/}}
+{{- define "novu-worker.fullname" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) "worker" -}}
+{{- end -}}
 {{/*
 Return the proper worker image name
 */}}
@@ -73,7 +84,12 @@ Return the proper image name (for the init container volume-permissions image)
 {{- include "common.images.image" ( dict "imageRoot" "global" .Values.global ) -}}
 {{- end -}}
 
-
+{{/*
+Return Novu web service deployment full name
+*/}}
+{{- define "novu-ws.fullname" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) "ws" -}}
+{{- end -}}
 {{/*
 Return the proper ws image name
 */}}
@@ -88,6 +104,12 @@ Return the proper image name (for the init container volume-permissions image)
 {{- include "common.images.image" ( dict "imageRoot" "global" .Values.global ) -}}
 {{- end -}}
 
+{{/*
+Return Novu web service deployment full name
+*/}}
+{{- define "novu-web.fullname" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) "web" -}}
+{{- end -}}
 {{/*
 Return the proper web image name
 */}}

--- a/helm/templates/api/deployment.yaml
+++ b/helm/templates/api/deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "api"  }}
+  name: {{ include "novu-api.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "api"  }}
+    app.kubernetes.io/component: {{ include "novu-api.fullname" . }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -20,14 +20,14 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "api"  }}
+      app.kubernetes.io/component: {{ include "novu-api.fullname" . }}
   template:
     metadata:
       {{- if .Values.api.podAnnotations }}
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.api.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "api"  }}
+        app.kubernetes.io/component: {{ include "novu-api.fullname" . }}
         {{- if .Values.api.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.api.podLabels "context" $) | nindent 8 }}
         {{- end }}

--- a/helm/templates/api/ingress.yaml
+++ b/helm/templates/api/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "api"  }}
+  name: {{ include "novu-api.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -31,7 +31,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.api.ingress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName"  (printf "%s-%s" .Release.Name "api") "servicePort" "http" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName"  (include "novu-api.fullname") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.api.ingress.extraHosts }}
     - host: {{ include "common.tplvalues.render" ( dict "value" .name "context" $ ) }}
@@ -41,7 +41,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s" .Release.Name "api") "servicePort" "http" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "novu-api.fullname") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.api.ingress.extraRules }}
     {{- include "common.tplvalues.render" (dict "value" .Values.api.ingress.extraRules "context" $) | nindent 4 }}

--- a/helm/templates/api/service.yaml
+++ b/helm/templates/api/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "api"  }}
+  name: {{ include "novu-api.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "api"  }}
+    app.kubernetes.io/component: {{ include "novu-api.fullname" . }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -27,4 +27,4 @@ spec:
     {{- include "common.tplvalues.render" (dict "value" .Values.api.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "api"  }}
+    app.kubernetes.io/component: {{ include "novu-api.fullname" . }}

--- a/helm/templates/externals3-secrets.yaml
+++ b/helm/templates/externals3-secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "externals3"  }}
+  name: {{ include "novu.s3.secretName"  }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/helm/templates/localstack-secrets.yaml
+++ b/helm/templates/localstack-secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "localstack"  }}
+  name: {{ include "novu.s3.secretName"  }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/helm/templates/web/deployment.yaml
+++ b/helm/templates/web/deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "web"  }}
+  name: {{ include "novu-web.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "web"  }}
+    app.kubernetes.io/component: {{ include "novu-web.fullname" . }}
 
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -21,14 +21,14 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "web"  }}
+      app.kubernetes.io/component: {{ include "novu-web.fullname" . }}
   template:
     metadata:
       {{- if .Values.web.podAnnotations }}
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.web.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "web"  }}
+        app.kubernetes.io/component: {{ include "novu-web.fullname" . }}
         {{- if .Values.web.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.web.podLabels "context" $) | nindent 8 }}
         {{- end }}

--- a/helm/templates/web/ingress.yaml
+++ b/helm/templates/web/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "web"  }}
+  name: {{ include "novu-web.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -31,7 +31,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.web.ingress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName"  (printf "%s-%s" .Release.Name "web")  "servicePort" "http" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName"  (include "novu-web.fullname")  "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.web.ingress.extraHosts }}
     - host: {{ include "common.tplvalues.render" ( dict "value" .name "context" $ ) }}
@@ -41,7 +41,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName"  (printf "%s-%s" .Release.Name "web")  "servicePort" "http" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName"  (include "novu-web.fullname")  "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.web.ingress.extraRules }}
     {{- include "common.tplvalues.render" (dict "value" .Values.web.ingress.extraRules "context" $) | nindent 4 }}

--- a/helm/templates/web/service.yaml
+++ b/helm/templates/web/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "web"  }}
+  name: {{ include "novu-web.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "web"  }}
+    app.kubernetes.io/component: {{ include "novu-web.fullname" . }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -27,4 +27,4 @@ spec:
     {{- include "common.tplvalues.render" (dict "value" .Values.web.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "web"  }}
+    app.kubernetes.io/component: {{ include "novu-web.fullname" . }}

--- a/helm/templates/worker/deployment.yaml
+++ b/helm/templates/worker/deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "worker"  }}
+  name: {{ include "novu-worker.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "worker"  }}
+    app.kubernetes.io/component: {{ include "novu-worker.fullname" . }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -20,14 +20,14 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "worker"  }}
+      app.kubernetes.io/component: {{ include "novu-worker.fullname" . }}
   template:
     metadata:
       {{- if .Values.worker.podAnnotations }}
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.worker.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "worker"  }}
+        app.kubernetes.io/component: {{ include "novu-worker.fullname" . }}
         {{- if .Values.worker.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.worker.podLabels "context" $) | nindent 8 }}
         {{- end }}

--- a/helm/templates/worker/service.yaml
+++ b/helm/templates/worker/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "worker"  }}
+  name: {{ include "novu-worker.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "worker"  }}
+    app.kubernetes.io/component: {{ include "novu-worker.fullname" . }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -27,4 +27,4 @@ spec:
     {{- include "common.tplvalues.render" (dict "value" .Values.worker.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "worker"  }}
+    app.kubernetes.io/component: {{ include "novu-worker.fullname" . }}

--- a/helm/templates/ws/deployment.yaml
+++ b/helm/templates/ws/deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "ws"  }}
+  name: {{ include "novu-ws.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "ws"  }}
+    app.kubernetes.io/component: {{ include "novu-ws.fullname" . }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -20,14 +20,14 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "ws"  }}
+      app.kubernetes.io/component: {{ include "novu-ws.fullname" . }}
   template:
     metadata:
       {{- if .Values.ws.podAnnotations }}
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.ws.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "ws"  }}
+        app.kubernetes.io/component: {{ include "novu-ws.fullname" . }}
         {{- if .Values.ws.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.ws.podLabels "context" $) | nindent 8 }}
         {{- end }}

--- a/helm/templates/ws/ingress.yaml
+++ b/helm/templates/ws/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "ws"  }}
+  name: {{ include "novu-ws.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -31,7 +31,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ws.ingress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName"  (printf "%s-%s" .Release.Name "ws")  "servicePort" "http" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName"  (include "novu-ws.fullname")  "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ws.ingress.extraHosts }}
     - host: {{ include "common.tplvalues.render" ( dict "value" .name "context" $ ) }}
@@ -41,7 +41,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName"  (printf "%s-%s" .Release.Name "ws")  "servicePort" "http" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName"  (include "novu-ws.fullname")  "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ws.ingress.extraRules }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ws.ingress.extraRules "context" $) | nindent 4 }}

--- a/helm/templates/ws/service.yaml
+++ b/helm/templates/ws/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "ws"  }}
+  name: {{ include "novu-ws.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "ws"  }}
+    app.kubernetes.io/component: {{ include "novu-ws.fullname" . }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -27,4 +27,4 @@ spec:
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ printf "%s-%s" .Release.Name "ws"  }}
+    app.kubernetes.io/component: {{ include "novu-ws.fullname" . }}


### PR DESCRIPTION
Some deployments and services ignored name and fullname overrides. They were using a hard-coded name using release name.

This PR replaces such hard-coded names with Bitnami (full)name override rules.

NOTE: these changes are not backward compatible, but as long as users have not used `fullnameOverride` for their installations, it should not impact them, as bitnami by default use the release name to build resource names.